### PR TITLE
ios: add missing websocket/ios client methods

### DIFF
--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -278,5 +278,109 @@ func main() {
 		}
 	}
 
+	// ========================================================================
+	// Device Info
+	// ========================================================================
+	fmt.Println("\n--- Testing DeviceInfo ---")
+	if info, err := client.DeviceInfo(ctx); err != nil {
+		log.Printf("Failed to get device info: %v", err)
+	} else {
+		fmt.Printf("Device: %s (%s), %.0fx%.0f\n", info.Model, info.UDID, info.ScreenWidth, info.ScreenHeight)
+	}
+
+	// ========================================================================
+	// Toggle Keyboard
+	// ========================================================================
+	fmt.Println("\n--- Testing ToggleKeyboard ---")
+	if err := client.ToggleKeyboard(ctx); err != nil {
+		log.Printf("Failed to toggle keyboard: %v", err)
+	} else {
+		fmt.Println("Toggled software keyboard")
+	}
+
+	// ========================================================================
+	// Scroll
+	// ========================================================================
+	fmt.Println("\n--- Testing Scroll ---")
+	if err := client.Scroll(ctx, websocket.ScrollDown, 300, nil); err != nil {
+		log.Printf("Failed to scroll: %v", err)
+	} else {
+		fmt.Println("Scrolled down 300px")
+	}
+
+	// ========================================================================
+	// Perform Actions (batched, runs in the pod without round-trips)
+	// ========================================================================
+	fmt.Println("\n--- Testing PerformActions ---")
+	actionsResult, err := client.PerformActions(ctx, []websocket.PerformAction{
+		websocket.ActionTap(screenshot.Width/2, screenshot.Height/2),
+		websocket.ActionWait(250),
+		websocket.ActionTypeText("batched input", false),
+	})
+	if err != nil {
+		log.Printf("PerformActions failed: %v", err)
+	} else {
+		fmt.Printf("PerformActions ran %d actions\n", len(actionsResult.Results))
+	}
+
+	// ========================================================================
+	// Launch App with explicit mode
+	// ========================================================================
+	fmt.Println("\n--- Testing LaunchApp with mode ---")
+	if err := client.LaunchApp(ctx, "com.apple.mobilesafari", websocket.WithLaunchMode(websocket.LaunchModeRelaunchIfRunning)); err != nil {
+		log.Printf("Failed to relaunch Safari: %v", err)
+	} else {
+		fmt.Println("Relaunched Safari")
+	}
+
+	// ========================================================================
+	// App Log Tail
+	// ========================================================================
+	fmt.Println("\n--- Testing AppLogTail ---")
+	if logs, err := client.AppLogTail(ctx, "com.apple.mobilesafari", 20); err != nil {
+		log.Printf("Failed to tail app log: %v", err)
+	} else {
+		fmt.Printf("Got %d bytes of Safari logs\n", len(logs))
+	}
+
+	// ========================================================================
+	// Stream Syslog (for 2s)
+	// ========================================================================
+	fmt.Println("\n--- Testing StreamSyslog ---")
+	if stream, err := client.StreamSyslog(ctx); err != nil {
+		log.Printf("Failed to start syslog stream: %v", err)
+	} else {
+		streamCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		lineCount := 0
+	loop:
+		for {
+			select {
+			case batch, ok := <-stream.Lines():
+				if !ok {
+					break loop
+				}
+				lineCount += len(batch)
+			case err := <-stream.Err():
+				log.Printf("Syslog stream error: %v", err)
+				break loop
+			case <-streamCtx.Done():
+				break loop
+			}
+		}
+		cancel()
+		stream.Stop()
+		fmt.Printf("Received %d syslog lines\n", lineCount)
+	}
+
+	// ========================================================================
+	// Terminate App
+	// ========================================================================
+	fmt.Println("\n--- Testing TerminateApp ---")
+	if err := client.TerminateApp(ctx, "com.apple.mobilesafari"); err != nil {
+		log.Printf("Failed to terminate Safari: %v", err)
+	} else {
+		fmt.Println("Terminated Safari")
+	}
+
 	fmt.Println("\n✅ All tests completed!")
 }

--- a/websocket/ios/actions.go
+++ b/websocket/ios/actions.go
@@ -1,0 +1,199 @@
+package ios
+
+import (
+	"context"
+	"fmt"
+)
+
+// PerformAction is a single action in a PerformActions batch. The Type field
+// is the discriminator and matches the request-side message type used by the
+// equivalent single-action methods. Only the fields relevant to a given Type
+// are populated; the rest are omitted on the wire.
+//
+// Prefer the Action* constructor helpers (ActionTap, ActionTypeText, ...) to
+// build values of this type.
+//
+// HID primitives (touchDown/touchMove/touchUp, keyDown/keyUp, buttonDown/
+// buttonUp) are deliberately unpaired so callers can build their own gestures
+// (e.g. long-press = touchDown + wait + touchUp).
+type PerformAction struct {
+	Type         string                 `json:"type"`
+	X            float64                `json:"x,omitempty"`
+	Y            float64                `json:"y,omitempty"`
+	ScreenWidth  float64                `json:"screenWidth,omitempty"`
+	ScreenHeight float64                `json:"screenHeight,omitempty"`
+	Selector     *AccessibilitySelector `json:"selector,omitempty"`
+	Text         string                 `json:"text,omitempty"`
+	PressEnter   bool                   `json:"pressEnter,omitempty"`
+	Key          string                 `json:"key,omitempty"`
+	Modifiers    []string               `json:"modifiers,omitempty"`
+	Direction    ScrollDirection        `json:"direction,omitempty"`
+	Pixels       float64                `json:"pixels,omitempty"`
+	Coordinate   []float64              `json:"coordinate,omitempty"`
+	Momentum     float64                `json:"momentum,omitempty"`
+	URL          string                 `json:"url,omitempty"`
+	Orientation  Orientation            `json:"orientation,omitempty"`
+	DurationMs   int                    `json:"durationMs,omitempty"`
+	KeyCode      int                    `json:"keyCode,omitempty"`
+	Button       string                 `json:"button,omitempty"`
+}
+
+// PerformActionResult is the per-action result in a PerformActions batch. Type
+// identifies which action the result corresponds to; Error is non-empty when
+// that action failed. Element-based actions additionally populate ElementLabel
+// and ElementType on success.
+type PerformActionResult struct {
+	Type         string `json:"type"`
+	ElementLabel string `json:"elementLabel,omitempty"`
+	ElementType  string `json:"elementType,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// PerformActionsResult is the aggregate result of a successful PerformActions
+// call. Results has one entry per submitted action.
+type PerformActionsResult struct {
+	Results []PerformActionResult
+}
+
+// PerformActions runs a sequence of actions sequentially inside the pod,
+// without a client round-trip between steps. On the first failing action the
+// batch stops early and this method returns that action's error; on full
+// success it returns a Results slice with one entry per submitted action.
+//
+// The supplied context governs the client-side timeout. Because a batch may
+// include arbitrary wait durations, use a context with a deadline that
+// accounts for the total expected duration of the batch.
+func (c *Client) PerformActions(ctx context.Context, actions []PerformAction) (*PerformActionsResult, error) {
+	resp, err := c.sendRequest(ctx, &request{Type: "performActions", Actions: actions})
+	if err != nil {
+		return nil, err
+	}
+	// The batch stops on the first failing action; surface that as an error
+	// rather than letting callers proceed as if the whole batch succeeded.
+	if err := firstActionError(resp.Results); err != nil {
+		return nil, err
+	}
+	return &PerformActionsResult{Results: resp.Results}, nil
+}
+
+// firstActionError returns an error for the first result with a non-empty
+// Error, or nil if every action succeeded.
+func firstActionError(results []PerformActionResult) error {
+	for _, r := range results {
+		if r.Error != "" {
+			return fmt.Errorf("action %q failed: %s", r.Type, r.Error)
+		}
+	}
+	return nil
+}
+
+// ActionTap taps at the given coordinates (device's native screen dimensions).
+func ActionTap(x, y float64) PerformAction {
+	return PerformAction{Type: "tap", X: x, Y: y}
+}
+
+// ActionTapWithScreenSize taps at coordinates given in an explicit coordinate
+// space.
+func ActionTapWithScreenSize(x, y, screenWidth, screenHeight float64) PerformAction {
+	return PerformAction{Type: "tap", X: x, Y: y, ScreenWidth: screenWidth, ScreenHeight: screenHeight}
+}
+
+// ActionTapElement taps an accessibility element matching the selector.
+func ActionTapElement(selector AccessibilitySelector) PerformAction {
+	return PerformAction{Type: "tapElement", Selector: &selector}
+}
+
+// ActionIncrementElement increments an accessibility element.
+func ActionIncrementElement(selector AccessibilitySelector) PerformAction {
+	return PerformAction{Type: "incrementElement", Selector: &selector}
+}
+
+// ActionDecrementElement decrements an accessibility element.
+func ActionDecrementElement(selector AccessibilitySelector) PerformAction {
+	return PerformAction{Type: "decrementElement", Selector: &selector}
+}
+
+// ActionSetElementValue sets the value of an accessibility element.
+func ActionSetElementValue(text string, selector AccessibilitySelector) PerformAction {
+	return PerformAction{Type: "setElementValue", Text: text, Selector: &selector}
+}
+
+// ActionTypeText types text into the currently focused input field.
+func ActionTypeText(text string, pressEnter bool) PerformAction {
+	return PerformAction{Type: "typeText", Text: text, PressEnter: pressEnter}
+}
+
+// ActionPressKey presses a key on the keyboard, optionally with modifiers.
+func ActionPressKey(key string, modifiers ...string) PerformAction {
+	return PerformAction{Type: "pressKey", Key: key, Modifiers: modifiers}
+}
+
+// ActionScroll scrolls in the given direction by the specified number of
+// pixels. A nil opts uses the screen center with no momentum.
+func ActionScroll(direction ScrollDirection, pixels float64, opts *ScrollOptions) PerformAction {
+	a := PerformAction{Type: "scroll", Direction: direction, Pixels: pixels}
+	if opts != nil {
+		if opts.Coordinate != nil {
+			a.Coordinate = []float64{opts.Coordinate[0], opts.Coordinate[1]}
+		}
+		a.Momentum = opts.Momentum
+	}
+	return a
+}
+
+// ActionToggleKeyboard toggles the on-screen software keyboard visibility.
+func ActionToggleKeyboard() PerformAction {
+	return PerformAction{Type: "toggleKeyboard"}
+}
+
+// ActionOpenURL opens a URL in the simulator.
+func ActionOpenURL(url string) PerformAction {
+	return PerformAction{Type: "openUrl", URL: url}
+}
+
+// ActionSetOrientation sets the device orientation.
+func ActionSetOrientation(orientation Orientation) PerformAction {
+	return PerformAction{Type: "setOrientation", Orientation: orientation}
+}
+
+// ActionWait inserts an inline delay between actions.
+func ActionWait(durationMs int) PerformAction {
+	return PerformAction{Type: "wait", DurationMs: durationMs}
+}
+
+// ActionTouchDown is a raw HID touch-down primitive.
+func ActionTouchDown(x, y float64) PerformAction {
+	return PerformAction{Type: "touchDown", X: x, Y: y}
+}
+
+// ActionTouchMove is a raw HID touch-move primitive.
+func ActionTouchMove(x, y float64) PerformAction {
+	return PerformAction{Type: "touchMove", X: x, Y: y}
+}
+
+// ActionTouchUp is a raw HID touch-up primitive.
+func ActionTouchUp(x, y float64) PerformAction {
+	return PerformAction{Type: "touchUp", X: x, Y: y}
+}
+
+// ActionKeyDown is a raw HID key-down primitive.
+func ActionKeyDown(keyCode int) PerformAction {
+	return PerformAction{Type: "keyDown", KeyCode: keyCode}
+}
+
+// ActionKeyUp is a raw HID key-up primitive.
+func ActionKeyUp(keyCode int) PerformAction {
+	return PerformAction{Type: "keyUp", KeyCode: keyCode}
+}
+
+// ActionButtonDown is a raw HID button-down primitive (e.g. "home", "lock",
+// "side", "applePay", "softwareKeyboard").
+func ActionButtonDown(button string) PerformAction {
+	return PerformAction{Type: "buttonDown", Button: button}
+}
+
+// ActionButtonUp is a raw HID button-up primitive (e.g. "home", "lock",
+// "side", "applePay", "softwareKeyboard").
+func ActionButtonUp(button string) PerformAction {
+	return PerformAction{Type: "buttonUp", Button: button}
+}

--- a/websocket/ios/http.go
+++ b/websocket/ios/http.go
@@ -1,0 +1,321 @@
+package ios
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+// activeRecordingFilename is the server-side filename of the active recording.
+const activeRecordingFilename = "recording.mp4"
+
+// apiBaseURL parses the client's API URL.
+func (c *Client) apiBaseURL() (*url.URL, error) {
+	u, err := url.Parse(c.apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid API URL: %w", err)
+	}
+	return u, nil
+}
+
+// httpJSON performs an HTTP request with an optional JSON body and decodes an
+// optional JSON response. Non-2xx responses are returned as errors that
+// include the response body.
+func (c *Client) httpJSON(ctx context.Context, method, rawURL string, reqBody, respBody any) error {
+	var body io.Reader
+	if reqBody != nil {
+		data, err := json.Marshal(reqBody)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s %s failed: %d %s", method, rawURL, resp.StatusCode, string(b))
+	}
+	if respBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+// Cp copies a local file into the simulator's sandbox under the given name and
+// returns the path usable in simctl commands.
+func (c *Client) Cp(ctx context.Context, name, filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	u, err := c.apiBaseURL()
+	if err != nil {
+		return "", err
+	}
+	u = u.JoinPath("files")
+	q := u.Query()
+	q.Set("name", name)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), f)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = info.Size()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("upload failed: %d %s", resp.StatusCode, string(b))
+	}
+	var result struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	return result.Path, nil
+}
+
+// SetStoreKitConfig registers a StoreKit local-test configuration for an app on
+// the simulator. The bytes are the contents of a .storekit file.
+func (c *Client) SetStoreKitConfig(ctx context.Context, bundleID string, storekit []byte) error {
+	u, err := c.apiBaseURL()
+	if err != nil {
+		return err
+	}
+	u = u.JoinPath("payments", "storeKitConfigs", bundleID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), bytes.NewReader(storekit))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = int64(len(storekit))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("setStoreKitConfig failed: %d %s", resp.StatusCode, string(b))
+	}
+	return nil
+}
+
+// ClearStoreKitConfig clears the registered StoreKit configuration for the
+// bundle. It is safe to call when nothing is registered.
+func (c *Client) ClearStoreKitConfig(ctx context.Context, bundleID string) error {
+	u, err := c.apiBaseURL()
+	if err != nil {
+		return err
+	}
+	u = u.JoinPath("payments", "storeKitConfigs", bundleID)
+	return c.httpJSON(ctx, http.MethodDelete, u.String(), nil, nil)
+}
+
+// StoreKitDiscoverOptions configures DiscoverStoreKitConfig.
+type StoreKitDiscoverOptions struct {
+	// TimeoutSeconds is how long the server blocks while polling for a sandbox
+	// response, clamped server-side to [1, 300]. A zero value uses the default
+	// (120).
+	TimeoutSeconds int
+}
+
+// StoreKitDiscoverResult is the result of auto-discovering a StoreKit
+// configuration.
+type StoreKitDiscoverResult struct {
+	ItemsFound              int
+	ProductsCount           int
+	SubscriptionsCount      int
+	SubscriptionGroupsCount int
+}
+
+// DiscoverStoreKitConfig auto-generates and registers a .storekit configuration
+// for the bundle by polling the simulator's storekitd cache for a captured
+// sandbox response. It blocks server-side for up to TimeoutSeconds.
+func (c *Client) DiscoverStoreKitConfig(ctx context.Context, bundleID string, opts *StoreKitDiscoverOptions) (*StoreKitDiscoverResult, error) {
+	timeoutSeconds := 120
+	if opts != nil && opts.TimeoutSeconds != 0 {
+		timeoutSeconds = opts.TimeoutSeconds
+	}
+
+	u, err := c.apiBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	u = u.JoinPath("payments", "storeKitConfigs", bundleID, "discover")
+
+	reqBody := map[string]any{"timeoutSeconds": timeoutSeconds}
+	var result struct {
+		ItemsFound              int `json:"itemsFound"`
+		ProductsCount           int `json:"productsCount"`
+		SubscriptionsCount      int `json:"subscriptionsCount"`
+		SubscriptionGroupsCount int `json:"subscriptionGroupsCount"`
+	}
+	if err := c.httpJSON(ctx, http.MethodPost, u.String(), reqBody, &result); err != nil {
+		return nil, fmt.Errorf("discoverStoreKitConfig: %w", err)
+	}
+	return &StoreKitDiscoverResult{
+		ItemsFound:              result.ItemsFound,
+		ProductsCount:           result.ProductsCount,
+		SubscriptionsCount:      result.SubscriptionsCount,
+		SubscriptionGroupsCount: result.SubscriptionGroupsCount,
+	}, nil
+}
+
+// SoftResetStrategy is the strategy used by SoftReset.
+type SoftResetStrategy string
+
+const (
+	// SoftResetData terminates and wipes the app's data container only.
+	SoftResetData SoftResetStrategy = "data"
+	// SoftResetFull restores freshly-opened-simulator state (uninstall +
+	// reinstall, clear keychain, privacy, NSUserDefaults cache, and shared App
+	// Group containers).
+	SoftResetFull SoftResetStrategy = "full"
+)
+
+// SoftResetOptions configures SoftReset.
+type SoftResetOptions struct {
+	// Strategy is the reset strategy. An empty value defaults to SoftResetData
+	// server-side.
+	Strategy SoftResetStrategy
+}
+
+// SoftResetResult is the result of a SoftReset call.
+type SoftResetResult struct {
+	// Strategy is the strategy that was actually applied.
+	Strategy SoftResetStrategy
+	// BundleID is the bundle ID that was reset.
+	BundleID string
+	// ItemsCleared is the number of top-level entries removed from the app's
+	// data container. Only populated when the data strategy is used.
+	ItemsCleared int
+	// DurationMs is the wall-clock duration of the reset on the server.
+	DurationMs float64
+}
+
+// SoftReset soft-resets an installed app on the simulator. Both strategies
+// relaunch the app after the reset completes.
+func (c *Client) SoftReset(ctx context.Context, bundleID string, opts *SoftResetOptions) (*SoftResetResult, error) {
+	body := map[string]any{"bundleId": bundleID}
+	if opts != nil && opts.Strategy != "" {
+		body["strategy"] = opts.Strategy
+	}
+
+	u, err := c.apiBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	u = u.JoinPath("softReset")
+
+	var result struct {
+		Strategy     SoftResetStrategy `json:"strategy"`
+		BundleID     string            `json:"bundleId"`
+		ItemsCleared int               `json:"itemsCleared"`
+		DurationMs   float64           `json:"durationMs"`
+	}
+	if err := c.httpJSON(ctx, http.MethodPost, u.String(), body, &result); err != nil {
+		return nil, fmt.Errorf("softReset: %w", err)
+	}
+	return &SoftResetResult{
+		Strategy:     result.Strategy,
+		BundleID:     result.BundleID,
+		ItemsCleared: result.ItemsCleared,
+		DurationMs:   result.DurationMs,
+	}, nil
+}
+
+// StopRecording stops the active server-side recording. If saveTo.PresignedURL
+// is set, the server uploads the completed file there before resolving. If
+// saveTo.LocalPath is set, the client downloads the completed file to that
+// path. It returns a download URL for the completed recording that is valid
+// while the instance is running.
+func (c *Client) StopRecording(ctx context.Context, saveTo SaveRecordingTo) (string, error) {
+	req := &request{Type: "stopVideoRecording"}
+	if saveTo.PresignedURL != "" {
+		req.Upload = &recordingUpload{PresignedURL: saveTo.PresignedURL}
+	}
+	if _, err := c.sendRequest(ctx, req); err != nil {
+		return "", err
+	}
+
+	u, err := c.apiBaseURL()
+	if err != nil {
+		return "", err
+	}
+	u = u.JoinPath("files")
+	q := u.Query()
+	q.Set("name", activeRecordingFilename)
+	u.RawQuery = q.Encode()
+	downloadURL := u.String()
+
+	if saveTo.LocalPath != "" {
+		if err := c.downloadFile(ctx, downloadURL, saveTo.LocalPath); err != nil {
+			return "", err
+		}
+	}
+	return downloadURL, nil
+}
+
+// downloadFile downloads rawURL (with bearer auth) to localPath.
+func (c *Client) downloadFile(ctx context.Context, rawURL, localPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("download failed: %d %s", resp.StatusCode, string(b))
+	}
+	f, err := os.Create(localPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return err
+	}
+	return nil
+}

--- a/websocket/ios/logstream.go
+++ b/websocket/ios/logstream.go
@@ -1,0 +1,170 @@
+package ios
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gorilla/websocket"
+)
+
+// LogStream is a handle to a running log subscription (app logs or syslog). It
+// uses a dedicated WebSocket connection separate from the main signaling
+// connection and delivers batched log lines (typically every ~500ms).
+//
+// Consume lines from the Lines channel and watch the Err channel for a
+// terminal error. Call Stop to unsubscribe and close the connection. A server
+// error message or a dropped connection also terminates the stream. In all
+// cases the Lines channel is closed when the stream ends, so ranging over it
+// terminates.
+type LogStream struct {
+	ws             *websocket.Conn
+	subscriptionID string
+	terminateType  string
+
+	linesCh chan []string
+	errCh   chan error
+	done    chan struct{}
+
+	closeDone sync.Once
+	closed    atomic.Bool
+}
+
+// logStreamMessage is a message from the log stream WebSocket.
+type logStreamMessage struct {
+	Type  string   `json:"type"`
+	ID    string   `json:"id"`
+	Lines []string `json:"lines"`
+	Error string   `json:"error"`
+}
+
+// StreamAppLog streams logs for the given bundle ID. The provided context
+// governs only the initial connection; use Stop to end the stream.
+func (c *Client) StreamAppLog(ctx context.Context, bundleID string) (*LogStream, error) {
+	return c.startLogStream(ctx, map[string]any{"type": "streamAppLog", "bundleId": bundleID}, "streamAppLogTerminate")
+}
+
+// StreamSyslog streams the device syslog. The provided context governs only
+// the initial connection; use Stop to end the stream.
+func (c *Client) StreamSyslog(ctx context.Context) (*LogStream, error) {
+	return c.startLogStream(ctx, map[string]any{"type": "streamSyslog"}, "streamSyslogTerminate")
+}
+
+func (c *Client) startLogStream(ctx context.Context, subscribe map[string]any, terminateType string) (*LogStream, error) {
+	wsURL, err := signalingURL(c.apiURL, c.token)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, http.Header{})
+	if err != nil {
+		return nil, fmt.Errorf("websocket dial: %w", err)
+	}
+
+	id := newSessionID()
+	subscribe["id"] = id
+
+	s := &LogStream{
+		ws:             conn,
+		subscriptionID: id,
+		terminateType:  terminateType,
+		linesCh:        make(chan []string, 16),
+		errCh:          make(chan error, 1),
+		done:           make(chan struct{}),
+	}
+
+	data, err := json.Marshal(subscribe)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("send subscribe: %w", err)
+	}
+
+	go s.readLoop()
+	return s, nil
+}
+
+// Lines returns the channel of batched log lines. The channel is closed when
+// the stream stops.
+func (s *LogStream) Lines() <-chan []string {
+	return s.linesCh
+}
+
+// Err returns a channel that receives at most one terminal error if the stream
+// fails (other than via an explicit Stop).
+func (s *LogStream) Err() <-chan error {
+	return s.errCh
+}
+
+func (s *LogStream) readLoop() {
+	defer close(s.linesCh)
+
+	for {
+		_, message, err := s.ws.ReadMessage()
+		if err != nil {
+			if !s.closed.Swap(true) {
+				s.emitErr(err)
+				s.shutdown()
+				s.ws.Close()
+			}
+			return
+		}
+
+		var msg logStreamMessage
+		if err := json.Unmarshal(message, &msg); err != nil {
+			// Ignore non-JSON messages.
+			continue
+		}
+		if msg.Error != "" {
+			// A server error message is terminal for the subscription: emit it
+			// and shut down so Lines() closes and consumers stop blocking.
+			s.emitErr(errors.New(msg.Error))
+			if !s.closed.Swap(true) {
+				s.shutdown()
+				s.ws.Close()
+			}
+			return
+		}
+		if len(msg.Lines) > 0 {
+			select {
+			case s.linesCh <- msg.Lines:
+			case <-s.done:
+				return
+			}
+		}
+	}
+}
+
+func (s *LogStream) emitErr(err error) {
+	select {
+	case s.errCh <- err:
+	default:
+	}
+}
+
+func (s *LogStream) shutdown() {
+	s.closeDone.Do(func() { close(s.done) })
+}
+
+// Stop unsubscribes and closes the dedicated WebSocket connection. It is safe
+// to call multiple times.
+func (s *LogStream) Stop() error {
+	if s.closed.Swap(true) {
+		return nil
+	}
+	s.shutdown()
+
+	// Best-effort terminate message before closing.
+	term, err := json.Marshal(map[string]any{"type": s.terminateType, "id": s.subscriptionID})
+	if err == nil {
+		_ = s.ws.WriteMessage(websocket.TextMessage, term)
+	}
+	return s.ws.Close()
+}

--- a/websocket/ios/logstream.go
+++ b/websocket/ios/logstream.go
@@ -124,9 +124,11 @@ func (s *LogStream) readLoop() {
 		}
 		if msg.Error != "" {
 			// A server error message is terminal for the subscription: emit it
-			// and shut down so Lines() closes and consumers stop blocking.
-			s.emitErr(errors.New(msg.Error))
+			// and shut down so Lines() closes and consumers stop blocking. Skip
+			// emitting if the stream was already stopped explicitly — Err() is
+			// only for failures other than an explicit Stop().
 			if !s.closed.Swap(true) {
+				s.emitErr(errors.New(msg.Error))
 				s.shutdown()
 				s.ws.Close()
 			}

--- a/websocket/ios/websocket.go
+++ b/websocket/ios/websocket.go
@@ -5,7 +5,9 @@ package ios
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -42,6 +44,35 @@ type AccessibilitySelector struct {
 type AccessibilityPoint struct {
 	X float64 `json:"x"`
 	Y float64 `json:"y"`
+}
+
+// ElementTreeFrame is the bounding box of an accessibility element.
+type ElementTreeFrame struct {
+	Height float64 `json:"height"`
+	Width  float64 `json:"width"`
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+}
+
+// ElementTreeNode is a single node in the accessibility hierarchy.
+type ElementTreeNode struct {
+	AXFrame         string            `json:"AXFrame"`
+	AXLabel         *string           `json:"AXLabel,omitempty"`
+	AXUniqueID      *string           `json:"AXUniqueId,omitempty"`
+	AXValue         *string           `json:"AXValue,omitempty"`
+	Children        []ElementTreeNode `json:"children,omitempty"`
+	ContentRequired bool              `json:"content_required"`
+	CustomActions   []string          `json:"custom_actions"`
+	Enabled         bool              `json:"enabled"`
+	Frame           ElementTreeFrame  `json:"frame"`
+	Help            *string           `json:"help,omitempty"`
+	PID             int               `json:"pid"`
+	Role            string            `json:"role"`
+	RoleDescription string            `json:"role_description"`
+	Subrole         *string           `json:"subrole,omitempty"`
+	Title           *string           `json:"title,omitempty"`
+	Traits          []string          `json:"traits"`
+	Type            string            `json:"type"`
 }
 
 // ScreenshotData contains the result of a screenshot operation.
@@ -111,11 +142,23 @@ func WithLogger(logger *slog.Logger) Option {
 	}
 }
 
+// WithHTTPClient sets a custom *http.Client used for the HTTP-based methods
+// (Cp, StoreKit config, SoftReset, recording download). Defaults to
+// http.DefaultClient.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = client
+	}
+}
+
 // Client is a WebSocket client for interacting with a Limrun iOS instance.
 type Client struct {
-	apiURL string
-	token  string
-	logger *slog.Logger
+	apiURL     string
+	token      string
+	logger     *slog.Logger
+	httpClient *http.Client
+
+	keepAliveSessionID string
 
 	ws               *websocket.Conn
 	wsMu             sync.Mutex
@@ -136,43 +179,162 @@ const (
 	OrientationLandscape Orientation = "Landscape"
 )
 
+// ScrollDirection is the direction content moves during a scroll.
+type ScrollDirection string
+
+const (
+	// ScrollUp moves content up.
+	ScrollUp ScrollDirection = "up"
+	// ScrollDown moves content down.
+	ScrollDown ScrollDirection = "down"
+	// ScrollLeft moves content left.
+	ScrollLeft ScrollDirection = "left"
+	// ScrollRight moves content right.
+	ScrollRight ScrollDirection = "right"
+)
+
+// ScrollOptions configures a Scroll call.
+type ScrollOptions struct {
+	// Coordinate is the starting [x, y] of the gesture. Defaults to the
+	// screen center when nil.
+	Coordinate *[2]float64
+	// Momentum controls scroll speed and inertia in the range 0.0-1.0.
+	// 0 (default) is a slow scroll with no momentum; 1 is fastest with max
+	// inertia.
+	Momentum float64
+}
+
+// LaunchAppRuntime is an optional runtime injected during LaunchApp. Runtime
+// launches always relaunch the app so injection is applied.
+type LaunchAppRuntime struct {
+	// Kind identifies the runtime, e.g. "detox".
+	Kind string `json:"kind"`
+	// ServerURL is the runtime's server URL.
+	ServerURL string `json:"serverUrl"`
+	// SessionID is the runtime session identifier.
+	SessionID string `json:"sessionId"`
+	// Version is the optional runtime version.
+	Version string `json:"version,omitempty"`
+}
+
+// LaunchAppOption configures a LaunchApp call.
+type LaunchAppOption func(*launchAppConfig)
+
+type launchAppConfig struct {
+	mode    LaunchMode
+	runtime *LaunchAppRuntime
+}
+
+// WithLaunchMode sets the launch behavior when the app may already be running.
+func WithLaunchMode(mode LaunchMode) LaunchAppOption {
+	return func(c *launchAppConfig) { c.mode = mode }
+}
+
+// WithLaunchRuntime attaches a runtime to inject during launch. The launch is
+// forced to RelaunchIfRunning so the runtime injection is applied.
+func WithLaunchRuntime(runtime LaunchAppRuntime) LaunchAppOption {
+	return func(c *launchAppConfig) { c.runtime = &runtime }
+}
+
+// CommandResult contains the result of a command execution (xcrun, xcodebuild).
+type CommandResult struct {
+	// Stdout is the decoded standard output of the command.
+	Stdout string
+	// Stderr is the decoded standard error of the command.
+	Stderr string
+	// ExitCode is the exit code of the command (-1 if unknown).
+	ExitCode int
+}
+
+// DeviceInfo contains information about the simulator device.
+type DeviceInfo struct {
+	// UDID is the device UDID.
+	UDID string
+	// ScreenWidth is the screen width in points.
+	ScreenWidth float64
+	// ScreenHeight is the screen height in points.
+	ScreenHeight float64
+	// Model is the device model name.
+	Model string
+}
+
+// RecordingOptions configures StartRecording.
+type RecordingOptions struct {
+	// Quality must be one of 5, 6, 7, 8, 9, 10. A zero value uses the server
+	// default (5).
+	Quality int
+}
+
+// SaveRecordingTo configures where StopRecording delivers the completed file.
+type SaveRecordingTo struct {
+	// PresignedURL, when set, makes the server upload the completed file there
+	// before resolving.
+	PresignedURL string
+	// LocalPath, when set, makes the client download the completed file to that
+	// path.
+	LocalPath string
+}
+
+type recordingUpload struct {
+	PresignedURL string `json:"presignedUrl"`
+}
+
 // request is an internal type for WebSocket requests.
 type request struct {
-	Type        string                 `json:"type"`
-	ID          string                 `json:"id"`
-	X           float64                `json:"x,omitempty"`
-	Y           float64                `json:"y,omitempty"`
-	Point       *AccessibilityPoint    `json:"point,omitempty"`
-	Selector    *AccessibilitySelector `json:"selector,omitempty"`
-	Text        string                 `json:"text,omitempty"`
-	PressEnter  bool                   `json:"pressEnter,omitempty"`
-	Key         string                 `json:"key,omitempty"`
-	Modifiers   []string               `json:"modifiers,omitempty"`
-	BundleID    string                 `json:"bundleId,omitempty"`
-	URL         string                 `json:"url,omitempty"`
-	Kind        string                 `json:"kind,omitempty"`
-	Args        []string               `json:"args,omitempty"`
-	MD5         string                 `json:"md5,omitempty"`
-	LaunchMode  LaunchMode             `json:"launchMode,omitempty"`
-	Orientation Orientation            `json:"orientation,omitempty"`
+	Type         string                 `json:"type"`
+	ID           string                 `json:"id"`
+	X            float64                `json:"x,omitempty"`
+	Y            float64                `json:"y,omitempty"`
+	ScreenWidth  float64                `json:"screenWidth,omitempty"`
+	ScreenHeight float64                `json:"screenHeight,omitempty"`
+	Point        *AccessibilityPoint    `json:"point,omitempty"`
+	Selector     *AccessibilitySelector `json:"selector,omitempty"`
+	Text         string                 `json:"text,omitempty"`
+	PressEnter   bool                   `json:"pressEnter,omitempty"`
+	Key          string                 `json:"key,omitempty"`
+	Modifiers    []string               `json:"modifiers,omitempty"`
+	BundleID     string                 `json:"bundleId,omitempty"`
+	URL          string                 `json:"url,omitempty"`
+	Kind         string                 `json:"kind,omitempty"`
+	Args         []string               `json:"args,omitempty"`
+	MD5          string                 `json:"md5,omitempty"`
+	LaunchMode   LaunchMode             `json:"launchMode,omitempty"`
+	Mode         LaunchMode             `json:"mode,omitempty"`
+	Runtime      *LaunchAppRuntime      `json:"runtime,omitempty"`
+	Orientation  Orientation            `json:"orientation,omitempty"`
+	Lines        int                    `json:"lines,omitempty"`
+	Direction    ScrollDirection        `json:"direction,omitempty"`
+	Pixels       float64                `json:"pixels,omitempty"`
+	Coordinate   []float64              `json:"coordinate,omitempty"`
+	Momentum     float64                `json:"momentum,omitempty"`
+	Actions      []PerformAction        `json:"actions,omitempty"`
+	Quality      int                    `json:"quality,omitempty"`
+	Upload       *recordingUpload       `json:"upload,omitempty"`
 }
 
 // response is an internal type for handling WebSocket responses.
 type response struct {
-	Type         string          `json:"type"`
-	ID           string          `json:"id"`
-	Error        string          `json:"error,omitempty"`
-	Base64       string          `json:"base64,omitempty"`
-	Width        float64         `json:"width,omitempty"`
-	Height       float64         `json:"height,omitempty"`
-	JSON         string          `json:"json,omitempty"`
-	ElementLabel string          `json:"elementLabel,omitempty"`
-	ElementType  string          `json:"elementType,omitempty"`
-	Apps         string          `json:"apps,omitempty"`
-	Files        json.RawMessage `json:"files,omitempty"`
-	URL          string          `json:"url,omitempty"`
-	BundleID     string          `json:"bundleId,omitempty"`
-	// simctlStream fields
+	Type         string                `json:"type"`
+	ID           string                `json:"id"`
+	Error        string                `json:"error,omitempty"`
+	Base64       string                `json:"base64,omitempty"`
+	Width        float64               `json:"width,omitempty"`
+	Height       float64               `json:"height,omitempty"`
+	JSON         string                `json:"json,omitempty"`
+	ElementLabel string                `json:"elementLabel,omitempty"`
+	ElementType  string                `json:"elementType,omitempty"`
+	Apps         string                `json:"apps,omitempty"`
+	Files        json.RawMessage       `json:"files,omitempty"`
+	URL          string                `json:"url,omitempty"`
+	BundleID     string                `json:"bundleId,omitempty"`
+	Logs         string                `json:"logs,omitempty"`
+	Results      []PerformActionResult `json:"results,omitempty"`
+	// deviceInfo fields
+	UDID         string  `json:"udid,omitempty"`
+	ScreenWidth  float64 `json:"screenWidth,omitempty"`
+	ScreenHeight float64 `json:"screenHeight,omitempty"`
+	Model        string  `json:"model,omitempty"`
+	// simctlStream / command (xcrun, xcodebuild) fields
 	Stdout   string `json:"stdout,omitempty"`
 	Stderr   string `json:"stderr,omitempty"`
 	ExitCode *int   `json:"exitCode,omitempty"`
@@ -181,10 +343,12 @@ type response struct {
 // NewClient creates a new WebSocket client and connects to the given API URL.
 func NewClient(apiURL, token string, opts ...Option) (*Client, error) {
 	c := &Client{
-		apiURL: apiURL,
-		token:  token,
-		logger: slog.Default(),
-		done:   make(chan struct{}),
+		apiURL:             apiURL,
+		token:              token,
+		logger:             slog.Default(),
+		httpClient:         http.DefaultClient,
+		keepAliveSessionID: newSessionID(),
+		done:               make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -196,19 +360,39 @@ func NewClient(apiURL, token string, opts ...Option) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) connect() error {
-	wsURL := strings.Replace(strings.Replace(c.apiURL, "https://", "wss://", 1), "http://", "ws://", 1)
+// signalingURL converts an http(s) API URL into the ws(s) signaling endpoint
+// URL, including the auth token query parameter.
+func signalingURL(apiURL, token string) (string, error) {
+	wsURL := strings.Replace(strings.Replace(apiURL, "https://", "wss://", 1), "http://", "ws://", 1)
 
 	u, err := url.Parse(wsURL)
 	if err != nil {
-		return fmt.Errorf("invalid API URL: %w", err)
+		return "", fmt.Errorf("invalid API URL: %w", err)
 	}
 	u = u.JoinPath("signaling")
 	q := u.Query()
-	q.Set("token", c.token)
+	q.Set("token", token)
 	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
 
-	ws, _, err := websocket.DefaultDialer.Dial(u.String(), http.Header{})
+// newSessionID returns a random hex identifier, falling back to a
+// timestamp-based value if the system RNG is unavailable.
+func newSessionID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("go-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
+}
+
+func (c *Client) connect() error {
+	wsURL, err := signalingURL(c.apiURL, c.token)
+	if err != nil {
+		return err
+	}
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{})
 	if err != nil {
 		return fmt.Errorf("websocket dial: %w", err)
 	}
@@ -364,7 +548,8 @@ func (c *Client) Screenshot(ctx context.Context) (*ScreenshotData, error) {
 	}, nil
 }
 
-// ElementTree returns the accessibility hierarchy of the current screen.
+// ElementTree returns the raw accessibility hierarchy JSON of the current
+// screen. Pass a non-nil point to query the element at that specific location.
 func (c *Client) ElementTree(ctx context.Context, point *AccessibilityPoint) (string, error) {
 	resp, err := c.sendRequest(ctx, &request{Type: "elementTree", Point: point})
 	if err != nil {
@@ -373,9 +558,35 @@ func (c *Client) ElementTree(ctx context.Context, point *AccessibilityPoint) (st
 	return resp.JSON, nil
 }
 
-// Tap simulates a tap at the specified coordinates.
+// ElementTreeNodes returns the parsed accessibility hierarchy of the current
+// screen. Pass a non-nil point to query the element at that specific location.
+func (c *Client) ElementTreeNodes(ctx context.Context, point *AccessibilityPoint) ([]ElementTreeNode, error) {
+	raw, err := c.ElementTree(ctx, point)
+	if err != nil {
+		return nil, err
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	var nodes []ElementTreeNode
+	if err := json.Unmarshal([]byte(raw), &nodes); err != nil {
+		return nil, fmt.Errorf("parse element tree: %w", err)
+	}
+	return nodes, nil
+}
+
+// Tap simulates a tap at the specified coordinates, interpreted in the
+// device's native screen dimensions.
 func (c *Client) Tap(ctx context.Context, x, y float64) error {
 	_, err := c.sendRequest(ctx, &request{Type: "tap", X: x, Y: y})
+	return err
+}
+
+// TapWithScreenSize taps at coordinates given in an explicit coordinate space.
+// Use this when coordinates are in a different coordinate space than the
+// device's native dimensions.
+func (c *Client) TapWithScreenSize(ctx context.Context, x, y, screenWidth, screenHeight float64) error {
+	_, err := c.sendRequest(ctx, &request{Type: "tap", X: x, Y: y, ScreenWidth: screenWidth, ScreenHeight: screenHeight})
 	return err
 }
 
@@ -430,10 +641,49 @@ func (c *Client) PressKey(ctx context.Context, key string, modifiers ...string) 
 	return err
 }
 
-// LaunchApp launches an installed app by bundle identifier.
-func (c *Client) LaunchApp(ctx context.Context, bundleID string) error {
-	_, err := c.sendRequest(ctx, &request{Type: "launchApp", BundleID: bundleID})
+// ToggleKeyboard toggles the on-screen software keyboard visibility. This is
+// equivalent to pressing Cmd+K in the iOS Simulator.
+func (c *Client) ToggleKeyboard(ctx context.Context) error {
+	_, err := c.sendRequest(ctx, &request{Type: "toggleKeyboard"})
 	return err
+}
+
+// LaunchApp launches an installed app by bundle identifier.
+//
+// By default the app is brought to the foreground if already running. Pass
+// WithLaunchMode to change this, or WithLaunchRuntime to inject a runtime
+// (which forces RelaunchIfRunning).
+func (c *Client) LaunchApp(ctx context.Context, bundleID string, opts ...LaunchAppOption) error {
+	var cfg launchAppConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	mode := cfg.mode
+	if cfg.runtime != nil {
+		if cfg.mode == LaunchModeForegroundIfRunning {
+			return errors.New("launchApp runtime launches require RelaunchIfRunning so runtime injection is applied")
+		}
+		mode = LaunchModeRelaunchIfRunning
+	}
+	_, err := c.sendRequest(ctx, &request{Type: "launchApp", BundleID: bundleID, Mode: mode, Runtime: cfg.runtime})
+	return err
+}
+
+// TerminateApp terminates a running app by bundle identifier. It succeeds
+// silently if the app is not currently running.
+func (c *Client) TerminateApp(ctx context.Context, bundleID string) error {
+	_, err := c.sendRequest(ctx, &request{Type: "terminateApp", BundleID: bundleID})
+	return err
+}
+
+// AppLogTail returns the last N lines of an app's logs (combined stdout/stderr).
+// The line count is clamped to the server limit.
+func (c *Client) AppLogTail(ctx context.Context, bundleID string, lines int) (string, error) {
+	resp, err := c.sendRequest(ctx, &request{Type: "appLogTail", BundleID: bundleID, Lines: lines})
+	if err != nil {
+		return "", err
+	}
+	return resp.Logs, nil
 }
 
 // ListApps returns a list of installed apps on the simulator.
@@ -491,6 +741,113 @@ func (c *Client) Lsof(ctx context.Context) ([]LsofEntry, error) {
 func (c *Client) SetOrientation(ctx context.Context, orientation Orientation) error {
 	_, err := c.sendRequest(ctx, &request{Type: "setOrientation", Orientation: orientation})
 	return err
+}
+
+// Scroll scrolls in the given direction by the specified number of pixels
+// (the finger movement distance). Pass opts to set the starting coordinate or
+// momentum; a nil opts uses the screen center with no momentum.
+func (c *Client) Scroll(ctx context.Context, direction ScrollDirection, pixels float64, opts *ScrollOptions) error {
+	req := &request{Type: "scroll", Direction: direction, Pixels: pixels}
+	if opts != nil {
+		if opts.Coordinate != nil {
+			req.Coordinate = []float64{opts.Coordinate[0], opts.Coordinate[1]}
+		}
+		req.Momentum = opts.Momentum
+	}
+	_, err := c.sendRequest(ctx, req)
+	return err
+}
+
+// StartRecording starts recording simulator video. Use StopRecording to stop.
+// When opts.Quality is set it must be one of 5, 6, 7, 8, 9, or 10.
+func (c *Client) StartRecording(ctx context.Context, opts *RecordingOptions) error {
+	req := &request{Type: "startVideoRecording"}
+	if opts != nil && opts.Quality != 0 {
+		if opts.Quality < 5 || opts.Quality > 10 {
+			return errors.New("quality must be one of: 5, 6, 7, 8, 9, 10")
+		}
+		req.Quality = opts.Quality
+	}
+	_, err := c.sendRequest(ctx, req)
+	return err
+}
+
+// KeepAlive sends an application-level keepAlive message on the control
+// websocket. It is fire-and-forget and does not wait for a response.
+func (c *Client) KeepAlive() error {
+	if c.closed.Load() {
+		return ErrNotConnected
+	}
+	msg := struct {
+		Type      string `json:"type"`
+		SessionID string `json:"sessionId"`
+	}{Type: "keepAlive", SessionID: c.keepAliveSessionID}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	c.wsMu.Lock()
+	err = c.ws.WriteMessage(websocket.TextMessage, data)
+	c.wsMu.Unlock()
+	return err
+}
+
+// Xcrun runs an xcrun command with the given arguments and returns the
+// complete output once it finishes (non-streaming).
+//
+// Only the following flags are allowed (validated server-side): --sdk <value>,
+// --show-sdk-version, --show-sdk-build-version, --show-sdk-platform-version.
+func (c *Client) Xcrun(ctx context.Context, args ...string) (*CommandResult, error) {
+	return c.runCommand(ctx, "xcrun", args)
+}
+
+// Xcodebuild runs an xcodebuild command with the given arguments and returns
+// the complete output once it finishes (non-streaming). Only -version is
+// allowed (validated server-side).
+func (c *Client) Xcodebuild(ctx context.Context, args ...string) (*CommandResult, error) {
+	return c.runCommand(ctx, "xcodebuild", args)
+}
+
+func (c *Client) runCommand(ctx context.Context, msgType string, args []string) (*CommandResult, error) {
+	resp, err := c.sendRequest(ctx, &request{Type: msgType, Args: args})
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := decodeBase64(resp.Stdout)
+	if err != nil {
+		return nil, fmt.Errorf("decode stdout: %w", err)
+	}
+	stderr, err := decodeBase64(resp.Stderr)
+	if err != nil {
+		return nil, fmt.Errorf("decode stderr: %w", err)
+	}
+	exitCode := -1
+	if resp.ExitCode != nil {
+		exitCode = *resp.ExitCode
+	}
+	return &CommandResult{Stdout: string(stdout), Stderr: string(stderr), ExitCode: exitCode}, nil
+}
+
+func decodeBase64(s string) ([]byte, error) {
+	if s == "" {
+		return nil, nil
+	}
+	return base64.StdEncoding.DecodeString(s)
+}
+
+// DeviceInfo fetches information about the simulator device (UDID, screen
+// dimensions, and model).
+func (c *Client) DeviceInfo(ctx context.Context) (*DeviceInfo, error) {
+	resp, err := c.sendRequest(ctx, &request{Type: "deviceInfo"})
+	if err != nil {
+		return nil, err
+	}
+	return &DeviceInfo{
+		UDID:         resp.UDID,
+		ScreenWidth:  resp.ScreenWidth,
+		ScreenHeight: resp.ScreenHeight,
+		Model:        resp.Model,
+	}, nil
 }
 
 // Simctl creates a new SimctlCmd to run the given simctl arguments.

--- a/websocket/ios/websocket_test.go
+++ b/websocket/ios/websocket_test.go
@@ -1,0 +1,244 @@
+package ios
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestSignalingURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		apiURL    string
+		wantStart string
+	}{
+		{"https", "https://example.com/api", "wss://example.com/api/signaling"},
+		{"http", "http://example.com", "ws://example.com/signaling"},
+		{"trailing slash", "https://example.com/", "wss://example.com/signaling"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := signalingURL(tt.apiURL, "tok123")
+			if err != nil {
+				t.Fatalf("signalingURL: %v", err)
+			}
+			if !strings.HasPrefix(got, tt.wantStart) {
+				t.Errorf("got %q, want prefix %q", got, tt.wantStart)
+			}
+			if !strings.Contains(got, "token=tok123") {
+				t.Errorf("got %q, want token query", got)
+			}
+		})
+	}
+}
+
+func TestNewSessionIDUnique(t *testing.T) {
+	a, b := newSessionID(), newSessionID()
+	if a == "" || b == "" {
+		t.Fatal("session id is empty")
+	}
+	if a == b {
+		t.Errorf("expected unique session ids, got %q twice", a)
+	}
+}
+
+func TestDecodeBase64(t *testing.T) {
+	if b, err := decodeBase64(""); err != nil || b != nil {
+		t.Errorf("empty: got %v, %v; want nil, nil", b, err)
+	}
+	// "hi" base64 == "aGk="
+	if b, err := decodeBase64("aGk="); err != nil || string(b) != "hi" {
+		t.Errorf("got %q, %v; want \"hi\", nil", b, err)
+	}
+}
+
+func TestScrollRequestMarshal(t *testing.T) {
+	req := &request{
+		Type:       "scroll",
+		ID:         "abc",
+		Direction:  ScrollDown,
+		Pixels:     300,
+		Coordinate: []float64{10, 20},
+		Momentum:   0.5,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["direction"] != "down" {
+		t.Errorf("direction = %v, want down", m["direction"])
+	}
+	if m["pixels"] != float64(300) {
+		t.Errorf("pixels = %v, want 300", m["pixels"])
+	}
+	if m["momentum"] != 0.5 {
+		t.Errorf("momentum = %v, want 0.5", m["momentum"])
+	}
+	// Unrelated optional fields must be omitted.
+	if _, ok := m["bundleId"]; ok {
+		t.Error("bundleId should be omitted")
+	}
+}
+
+func TestActionConstructors(t *testing.T) {
+	tap := ActionTap(5, 6)
+	if tap.Type != "tap" || tap.X != 5 || tap.Y != 6 {
+		t.Errorf("ActionTap = %+v", tap)
+	}
+
+	typeText := ActionTypeText("hello", true)
+	if typeText.Type != "typeText" || typeText.Text != "hello" || !typeText.PressEnter {
+		t.Errorf("ActionTypeText = %+v", typeText)
+	}
+
+	wait := ActionWait(500)
+	if wait.Type != "wait" || wait.DurationMs != 500 {
+		t.Errorf("ActionWait = %+v", wait)
+	}
+
+	scroll := ActionScroll(ScrollLeft, 120, &ScrollOptions{Coordinate: &[2]float64{1, 2}, Momentum: 0.25})
+	if scroll.Type != "scroll" || scroll.Direction != ScrollLeft || scroll.Pixels != 120 {
+		t.Errorf("ActionScroll = %+v", scroll)
+	}
+	if len(scroll.Coordinate) != 2 || scroll.Coordinate[0] != 1 || scroll.Coordinate[1] != 2 {
+		t.Errorf("ActionScroll coordinate = %+v", scroll.Coordinate)
+	}
+
+	btn := ActionButtonDown("home")
+	if btn.Type != "buttonDown" || btn.Button != "home" {
+		t.Errorf("ActionButtonDown = %+v", btn)
+	}
+}
+
+func TestPerformActionMarshalOmitsEmpty(t *testing.T) {
+	data, err := json.Marshal(ActionTap(1, 2))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["type"] != "tap" {
+		t.Errorf("type = %v, want tap", m["type"])
+	}
+	for _, k := range []string{"selector", "text", "key", "direction", "button"} {
+		if _, ok := m[k]; ok {
+			t.Errorf("field %q should be omitted, got %v", k, m[k])
+		}
+	}
+}
+
+func TestLaunchAppRuntimeRequiresRelaunch(t *testing.T) {
+	c := &Client{}
+	err := c.LaunchApp(context.Background(), "com.example.app",
+		WithLaunchRuntime(LaunchAppRuntime{Kind: "detox", ServerURL: "ws://x", SessionID: "s"}),
+		WithLaunchMode(LaunchModeForegroundIfRunning),
+	)
+	if err == nil {
+		t.Fatal("expected error for runtime launch with ForegroundIfRunning")
+	}
+	if !strings.Contains(err.Error(), "RelaunchIfRunning") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestStartRecordingQualityValidation(t *testing.T) {
+	c := &Client{}
+	for _, q := range []int{1, 4, 11, 100} {
+		if err := c.StartRecording(context.Background(), &RecordingOptions{Quality: q}); err == nil {
+			t.Errorf("quality %d: expected validation error", q)
+		}
+	}
+}
+
+func TestKeepAliveNotConnected(t *testing.T) {
+	c := &Client{}
+	c.closed.Store(true)
+	if err := c.KeepAlive(); err != ErrNotConnected {
+		t.Errorf("KeepAlive = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestFirstActionError(t *testing.T) {
+	if err := firstActionError(nil); err != nil {
+		t.Errorf("nil results: got %v, want nil", err)
+	}
+	ok := []PerformActionResult{{Type: "tap"}, {Type: "typeText"}}
+	if err := firstActionError(ok); err != nil {
+		t.Errorf("all-ok results: got %v, want nil", err)
+	}
+	failing := []PerformActionResult{
+		{Type: "tap"},
+		{Type: "tapElement", Error: "element not found"},
+		{Type: "typeText", Error: "ignored second error"},
+	}
+	err := firstActionError(failing)
+	if err == nil {
+		t.Fatal("expected error for failing batch")
+	}
+	if !strings.Contains(err.Error(), "tapElement") || !strings.Contains(err.Error(), "element not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if strings.Contains(err.Error(), "ignored second error") {
+		t.Errorf("should report only the first failure: %v", err)
+	}
+}
+
+// TestLogStreamTerminatesOnServerError verifies that a server-side error
+// message terminates the stream: Err receives the error and Lines closes even
+// though the server keeps the underlying socket open.
+func TestLogStreamTerminatesOnServerError(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/signaling", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		_ = conn.WriteJSON(map[string]any{"type": "streamSyslog", "error": "boom"})
+		// Keep the socket open so termination is driven by the error message,
+		// not by a connection close.
+		time.Sleep(2 * time.Second)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &Client{apiURL: srv.URL, token: "t", httpClient: http.DefaultClient}
+	stream, err := c.StreamSyslog(context.Background())
+	if err != nil {
+		t.Fatalf("StreamSyslog: %v", err)
+	}
+
+	select {
+	case e := <-stream.Err():
+		if e == nil || !strings.Contains(e.Error(), "boom") {
+			t.Errorf("Err = %v, want error containing boom", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream error")
+	}
+
+	select {
+	case _, ok := <-stream.Lines():
+		if ok {
+			t.Error("expected Lines channel to be closed after terminal error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Lines channel not closed after terminal error")
+	}
+}


### PR DESCRIPTION
Port the directly-portable methods from the TypeScript SDK's ios-client.ts into the Go websocket/ios client:

- TapWithScreenSize, ToggleKeyboard, TerminateApp, AppLogTail
- Scroll, PerformActions (+Action* constructors)
- StartRecording / StopRecording, KeepAlive
- Xcrun / Xcodebuild, DeviceInfo, ElementTreeNodes (parsed tree)
- LaunchApp mode + runtime via functional options
- StreamAppLog / StreamSyslog (dedicated-connection LogStream)
- HTTP methods: Cp, SetStoreKitConfig, ClearStoreKitConfig, DiscoverStoreKitConfig, SoftReset (+WithHTTPClient option)

Add unit tests for the new pure logic and demonstrate the new methods in examples/websocket.

Subsystem-dependent members (syncApp, startReverseTunnel, startHttpProxy, startXcrunShim, connection-state) are intentionally not ported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad new public SDK surface and HTTP/WS paths that drive simulator apps, payments testing, and destructive soft-reset; behavior depends on server contract but changes are mostly additive client wrappers with unit tests.
> 
> **Overview**
> Brings the Go `websocket/ios` client closer to parity with the TypeScript `ios-client` by adding a large set of **new** control, HTTP, and streaming APIs, plus tests and example coverage.
> 
> **WebSocket control** gains scroll, batched `PerformActions` (with `Action*` helpers and fail-fast on first error), device info, keyboard toggle, app terminate/log tail, video start/stop recording, keep-alive, parsed `ElementTreeNodes`, coordinate-aware tap, `LaunchApp` functional options (mode + runtime injection), and non-streaming `Xcrun` / `Xcodebuild`. Shared wiring adds `signalingURL`, session IDs, and expanded request/response fields.
> 
> **Dedicated log streaming** uses a second WebSocket (`StreamAppLog` / `StreamSyslog`) with batched `Lines`, terminal `Err`, and `Stop`.
> 
> **HTTP helpers** (via `WithHTTPClient`) cover file upload (`Cp`), StoreKit config set/clear/discover, `SoftReset`, and recording download after `StopRecording`.
> 
> The websocket example exercises many of the new methods; unit tests cover marshaling, validation, batch errors, and log-stream shutdown on server errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e294fac0a09518fbe4176edd6a17355bc56737b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->